### PR TITLE
chore: add npm run deps:sync so dependency bumps stop landing red

### DIFF
--- a/README.md
+++ b/README.md
@@ -453,7 +453,30 @@ npm run test:regression:update   # update fixtures after an intentional change
 npm run test:compare             # live canonicalizer vs bundled snapshot
 npm run canonical:extract        # regenerate canonical replacement files
 npm run canonical:check          # verify canonical replacement files are current
+npm run deps:sync                # after a dependency bump: refresh bun.lock and rebuild dist/
 ```
+
+### Updating dependencies
+
+This repo commits **three** things that a dependency bump has to move together:
+
+| File | Written by | Enforced by |
+| --- | --- | --- |
+| `package.json` + `package-lock.json` | `npm` | `npm ci` in CI and the release workflow |
+| `bun.lock` | `bun` | prepush check *lockfiles agree on dependency versions* |
+| `dist/index.mjs` + `dist/normwind.mjs` | `@vercel/ncc`, via `npm run build:action` | prepush check *action: committed bundle is current* |
+
+Dependabot only knows about the first row. It has no way to update the other two, and no Dependabot configuration can fix that: `bun.lock` and `package-lock.json` describe the *same* `package.json`, so adding a second `package-ecosystem` would just open a second, conflicting PR for every bump. **Every Dependabot PR therefore arrives red on purpose, and finishing it is a manual step:**
+
+```bash
+gh pr checkout <number>
+npm run deps:sync
+git add bun.lock dist/            # only if they actually changed
+git commit -m "chore(deps): sync bun.lock and dist/ with the npm bump"
+git push
+```
+
+Note that `npm test` chains its three suites with `&&`, so a stale `bun.lock` short-circuits before the bundle check ever runs. If you fix only the lockfile, expect the `dist/` failure to appear on the next push. `npm run deps:sync` does both at once for exactly this reason.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -476,6 +476,8 @@ git commit -m "chore(deps): sync bun.lock and dist/ with the npm bump"
 git push
 ```
 
+`deps:sync` needs [Bun](https://bun.sh) on `PATH` for its first step; nothing else in the repo does, and CI never runs it. If you do not have Bun, ask someone who does to push the `bun.lock` half.
+
 Note that `npm test` chains its three suites with `&&`, so a stale `bun.lock` short-circuits before the bundle check ever runs. If you fix only the lockfile, expect the `dist/` failure to appear on the next push. `npm run deps:sync` does both at once for exactly this reason.
 
 </details>

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "build:action:check": "node scripts/build-action.mjs --check",
     "canonical:extract": "node bin/normwind.mjs --extract-canonical --write-canonical-files",
     "canonical:check": "node bin/normwind.mjs --check-canonical",
+    "deps:sync": "bun install && npm ci && npm run build:action",
     "test": "node scripts/test-units.mjs && node scripts/test-prepush.mjs && node scripts/test-action.mjs",
     "prepush": "npm test",
     "test:action": "node scripts/test-action.mjs",

--- a/scripts/test-prepush.mjs
+++ b/scripts/test-prepush.mjs
@@ -1020,6 +1020,11 @@ addCheck("lockfiles agree on dependency versions", async () => {
     // workflow) installs from; bun.lock is what local development uses. A
     // dependency bumped through one package manager must not leave the other
     // silently pinned to the old version.
+    //
+    // Dependabot only ever updates package.json + package-lock.json, so every
+    // one of its PRs lands here red until someone runs `npm run deps:sync`.
+    // That is the intended workflow, not a bug in this check -- see the
+    // "Updating dependencies" section of the README.
     const pkg = await readJson(path.join(REPO_ROOT, "package.json"));
     const declared = { ...(pkg.dependencies ?? {}), ...(pkg.devDependencies ?? {}) };
     const bunLock = await fs.readFile(path.join(REPO_ROOT, "bun.lock"), "utf8").catch(() => null);
@@ -1035,7 +1040,7 @@ addCheck("lockfiles agree on dependency versions", async () => {
         }
         assert(
             bunLock.includes(`"${name}@${exact}"`),
-            `bun.lock does not pin ${name}@${exact}; run \`bun install\` and commit the result`,
+            `bun.lock does not pin ${name}@${exact}; run \`npm run deps:sync\` and commit bun.lock (and dist/, if it changed)`,
         );
         const entry = npmLock.packages?.[`node_modules/${name}`];
         assert(


### PR DESCRIPTION
### Why

Dependabot updates `package.json` and `package-lock.json` and nothing else. This repo also commits `bun.lock` and an ncc-built `dist/`, so **every** Dependabot PR fails two prepush checks that are working exactly as designed:

- `lockfiles agree on dependency versions`
- `action: committed bundle is current`

#6 sat red for ten days on that alone. A dependency PR that is always red trains everyone to ignore Dependabot on this repo, and the next red one might be a real security bump.

### Why not just configure Dependabot

`bun.lock` and `package-lock.json` describe the *same* `package.json`. Adding a second `package-ecosystem: bun` entry for `/` would open a second PR for every bump, conflicting with the npm one on `package.json`. Switching entirely to the bun ecosystem just mirrors the problem onto `package-lock.json`. The follow-up is genuinely manual, so this makes it one documented command instead of tribal knowledge.

### What changed

- `npm run deps:sync` = `bun install && npm ci && npm run build:action`
- The lockfile check's failure message now names `deps:sync`. It previously said "run `bun install`", which fixes half the problem: `npm test` chains its three suites with `&&`, so the lockfile failure short-circuits before the bundle check runs, and you only discover the stale `dist/` on the *next* push.
- README gains an **Updating dependencies** section: the three artifacts a bump must move, who writes each, which check enforces it, and the checkout/sync/commit sequence.

No behavior change to the CLI or the Action.

### Verification

- `npm test` green on Windows
- `python ~/.claude/tools/localci.py --docker` green on all three Ubuntu Node legs (20.x / 22.x / 24.x)

🤖 Generated with [Claude Code](https://claude.com/claude-code)